### PR TITLE
Update go.mod to fix compilation issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module namecheap-dns
+module github.com/caddy-dns/namecheap
 
 go 1.16
 


### PR DESCRIPTION
xcaddy fails to build with this module with the below error

'module declares its path as: namecheap-dns but was required as: github.com/caddy-dns/namecheap'