### PR TITLE
Fix Namecheap API access

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ To use this module for the ACME DNS challenge, [configure the ACME issuer in you
       "provider": {
         "name": "namecheap",
         "api_key": "{env.NAMECHEAP_API_KEY}",
-        "user": "{env.NAMECHEAP_API_USER}"
+        "user": "{env.NAMECHEAP_API_USER}",
+        "api_endpoint": "https://api.namecheap.com/xml.response",
+        "client_ip": "deduced-automatically-if-not-set"
       }
     }
   }
@@ -37,9 +39,11 @@ or with the Caddyfile:
 
 ```
 tls {
-	dns namecheap {
+    dns namecheap {
         api_key {env.NAMECHEAP_API_KEY}
         user {env.NAMECHEAP_API_USER}
+        api_endpoint https://api.namecheap.com/xml.response
+        client_ip <client_ip>
     }
 }
 ```
@@ -55,8 +59,8 @@ A complete example
         dns namecheap {
             api_key {env.NAMECHEAP_API_KEY}
             user namecheap_api_username
+            api_endpoint https://api.namecheap.com/xml.response
             client_ip public_egress_ip
-            endpoint https://api.sandbox.namecheap.com/xml.response
         }
     }
 }

--- a/namecheap.go
+++ b/namecheap.go
@@ -34,10 +34,12 @@ func (p *Provider) Provision(ctx caddy.Context) error {
 
 // UnmarshalCaddyfile sets up the DNS provider from Caddyfile tokens. Syntax:
 //
-// namecheap {
-//     api_key <api_key>
-//     user <user>
-// }
+//	namecheap {
+//	    api_key <api_key>
+//	    user <user>
+//	    api_endpoint https://api.namecheap.com/xml.response
+//	    client_ip <client_ip>
+//	}
 //
 // Expansion of placeholders is left to the JSON config caddy.Provisioner (above).
 func (p *Provider) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
@@ -69,7 +71,7 @@ func (p *Provider) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				if d.NextArg() {
 					return d.ArgErr()
 				}
-			case "endpoint":
+			case "api_endpoint":
 				if p.Provider.APIEndpoint != "" {
 					return d.Err("API endpoint already set")
 				}


### PR DESCRIPTION
Fix Namecheap API access when using namecheap caddy dns plugin by changing parameter name from 'endpoint' to 'api_endpoint' since 'api_endpoint' is what is expected.

Also run `go fmt` on the file.

---

I have an installable branch here: https://github.com/boatrite/caddy-dns-namecheap/tree/fixed-api-installable

Use it like so:

```
xcaddy build --with github.com/boatrite/caddy-dns-namecheap@fixed-api-installable
```